### PR TITLE
Fix for issue #10 for travis python 3.4

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
     - "nightly"
 before_install:
     - pip install six
-install: 
+    - pip install packaging
     - pip install -r tests/requirements.txt
+install: 
     - python -m spacy download en_core_web_sm
 script: python -m pytest --spec --flake --cov=eulerbot --cov-report term-missing -m 'not spacy' tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
     - "3.4"
-    - "3.6"
-    - "nightly"
+      #    - "3.6"
+      #    - "nightly"
 before_install:
-    - pip install six
-    - pip install packaging
+    - pip install appdirs six packaging
     - pip install -r tests/requirements.txt
 install: 
     - python -m spacy download en_core_web_sm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
     - "3.4"
     - "3.6"
     - "nightly"
+before_install:
+    - pip install six
 install: 
     - pip install -r tests/requirements.txt
     - python -m spacy download en_core_web_sm

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,4 +10,5 @@ build:
         - mkdir -p shippable/codecoverage
         - shippable_retry pip install -r tests/requirements.txt
         - shippable_retry python -m spacy download en_core_web_sm
-        - python -m pytest --spec --flake --junitxml=shippable/testresults/tests.xml --cov=euler --cov-report xml:shippable/codecoverage/cov.xml
+        - shippable_retry python -m spacy.en.download all
+        - python -m pytest --spec --flake --junitxml=shippable/testresults/tests.xml --cov=eulerbot --cov-report xml:shippable/codecoverage/cov.xml

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+    - 3.4
+    - 3.6
+
+build:
+    ci:
+        - mkdir -p shippable/testresults
+        - mkdir -p shippable/codecoverage
+        - shippable_retry pip install -r tests/requirements.txt
+        - shippable_retry python -m spacy download en_core_web_sm
+        - python -m pytest --spec --flake --junitxml=shippable/testresults/tests.xml --cov=euler --cov-report xml:shippable/codecoverage/cov.xml


### PR DESCRIPTION
Fixes TravisCI Python 3.4 issue and introduces shippable as a potential replacement. 